### PR TITLE
Set text color in button to white to improve readability

### DIFF
--- a/src/stop-forum-spam-checker.user.js
+++ b/src/stop-forum-spam-checker.user.js
@@ -25,7 +25,7 @@ jQuery(document).ready(function( $ ) {
     if ( $IPs.length >= 1 ) {
         $IPs.each(function() {
             var address = $(this).text().replace( /(\(|\))/gi, '' );
-            $(this).append( '<button type="button" class="button button-primary button-small stop-forum-spam-check" style="margin-left:0.5rem;" data-ip="' + address + '">Check IP</button>' );
+            $(this).append( '<button type="button" class="button button-primary button-small stop-forum-spam-check" style="margin-left:0.5rem;color:#fff!important;" data-ip="' + address + '">Check IP</button>' );
         } );
     }
 


### PR DESCRIPTION
The button is readable, but when clicked *and* there's a spam result, the text color becomes a light blue, which is unreadable on the slightly darker blue button.